### PR TITLE
Fix/script build errors

### DIFF
--- a/scripts/deploy-civic.sh
+++ b/scripts/deploy-civic.sh
@@ -41,6 +41,7 @@ deploy_canister() {
 
 # Function to build canisters with retries
 build_canisters_with_retries() {
+  local network=$1
   local retries=3
   local count=0
   local success=false
@@ -48,7 +49,7 @@ build_canisters_with_retries() {
 
   until [ $count -ge $retries ]; do
     echo "Building canisters (attempt $((count+1))/$retries)..."
-    if dfx build >>$log_file 2>&1; then
+    if dfx build --network $network >>$log_file 2>&1; then
       success=true
       break
     else
@@ -118,8 +119,9 @@ main() {
     fi
   done
 
+  echo $(dfx canister id civic_canister_backend --ic)
   # Build the canisters with retries to ensure all necessary files are generated
-  build_canisters_with_retries
+  build_canisters_with_retries $network
 
   # Export environment variables
   if [ "$network" = "ic" ]; then


### PR DESCRIPTION
Output of the script 
```
Building canisters...
WARN: .did file for canister 'internet_identity' does not exist.
WARN: Cannot check for vulnerabilities in rust canisters because cargo-audit is not installed. Please run 'cargo install cargo-audit' so that vulnerabilities can be detected.
Building frontend...
WARN: Generating type declarations for canister relying_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did
Generating type declarations for canister internet_identity:
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.js
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did
Generating type declarations for canister civic_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did
Generating type declarations for canister civic_canister_backend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did
[plugin:vite:resolve] Module "assert" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/hdkey/lib/hdkey.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "crypto" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/hdkey/lib/hdkey.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "stream" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/cipher-base/index.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/readable-stream/lib/_stream_readable.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/readable-stream/lib/internal/streams/stream-browser.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.

Executing: cargo build --target wasm32-unknown-unknown --release -p civic_canister_backend --locked
    Finished release [optimized] target(s) in 0.38s
Building frontend...
WARN: Generating type declarations for canister relying_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did
Generating type declarations for canister internet_identity:
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.js
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did
Generating type declarations for canister civic_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did
Generating type declarations for canister civic_canister_backend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did

VITE_CIVIC_FRONTEND_CANISTER_ID=vouha-iyaaa-aaaag-qj5ia-cai
VITE_INTERNET_IDENTITY_CANISTER_ID=rdmx6-jaaaa-aaaaa-aaadq-cai
VITE_CIVIC_BACKEND_CANISTER_ID=xtjji-3qaaa-aaaag-qj5hq-cai
VITE_RELYING_FRONTEND_CANISTER_ID=vjvbu-faaaa-aaaag-qj5iq-cai
VITE_HOST=localhost:4943
VITE_ENV=production
Deploying: civic_canister_frontend
All canisters have already been created.
Building canisters...
WARN: .did file for canister 'internet_identity' does not exist.
Building frontend...
WARN: Generating type declarations for canister relying_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did
Generating type declarations for canister internet_identity:
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.js
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did
Generating type declarations for canister civic_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did
Generating type declarations for canister civic_canister_backend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did
[plugin:vite:resolve] Module "assert" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/hdkey/lib/hdkey.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "crypto" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/hdkey/lib/hdkey.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "stream" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/cipher-base/index.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/readable-stream/lib/_stream_readable.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.
[plugin:vite:resolve] Module "events" has been externalized for browser compatibility, imported by "/Users/lilly/civic/demo1/node_modules/readable-stream/lib/internal/streams/stream-browser.js". See http://vitejs.dev/guide/troubleshooting.html#module-externalized-for-browser-compatibility for more details.

(!) Some chunks are larger than 500 kBs after minification. Consider:
- Using dynamic import() to code-split the application
- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.

Installing canisters...
Installing code for canister civic_canister_frontend, with canister ID vouha-iyaaa-aaaag-qj5ia-cai
Uploading assets to asset canister...
Fetching properties for all assets in the canister.
Done fetching properties for all assets in the canister. Took 39.541µs
Starting batch.
Staging contents of new and changed assets in batch 1:
  /assets/index-45957a68.js 1/1 (978062 bytes) sha 7dde2fe4f7ead8f479185035e6515f6611d52752b34b20516c5d2f0dea3778fd (with 7 headers)
  /index.html 1/1 (417 bytes) sha 7c56f3e1807295bf19790d83c336f7855f16952a980ebd671aedc5aafdc23870 (with 7 headers)
  /assets/index-2a8a0c6e.css (gzip) 1/1 (267 bytes) sha 3c2c7eb54ceef927ffbdec6a59cb7013f31f683b2dcacecf070bcd2fe787b7ec (with 7 headers)
  /assets/index-2a8a0c6e.css 1/1 (386 bytes) sha 2a8a0c6efd388558fb59f2c3bcbf755c959b07d513139f8056b25b19a2d89de5 (with 7 headers)
  /assets/index-45957a68.js (gzip) 1/1 (326321 bytes) sha 5edefd65b6d9f79246d457df234e7ffabee9609eb7b9be435fee2b31d72824bd (with 7 headers)
  /logo2.svg 1/1 (15139 bytes) sha 037eb7ae523403daa588cf4f47a34c56a3f5de08a5a2dd2364839e45f14f4b8b (with 7 headers)
  /favicon.ico 1/1 (15406 bytes) sha 4e8d31b50ffb59695389d94e393d299c5693405a12f6ccd08c31bcf9b58db2d4 (with 7 headers)
  /index.html (gzip) 1/1 (283 bytes) sha a84438a1fddb460875b80da6abb50a4b0b3509ce0785813bc11bc7f19562645b (with 7 headers)
Committing batch.
Committing batch with 13 operations.
Deployed canisters.
URLs:
  Frontend canister via browser
    civic_canister_frontend: https://vouha-iyaaa-aaaag-qj5ia-cai.icp0.io/
    relying_canister_frontend: https://vjvbu-faaaa-aaaag-qj5iq-cai.icp0.io/
  Backend canister via Candid interface:
    civic_canister_backend: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.icp0.io/?id=xtjji-3qaaa-aaaag-qj5hq-cai
Deploying: relying_canister_frontend
All canisters have already been created.
Building canisters...
WARN: .did file for canister 'internet_identity' does not exist.
Building frontend...
WARN: Generating type declarations for canister relying_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/relying_canister_frontend/relying_canister_frontend.did
Generating type declarations for canister internet_identity:
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did.js
  /Users/lilly/civic/demo1/src/declarations/internet_identity/internet_identity.did
Generating type declarations for canister civic_canister_frontend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_frontend/civic_canister_frontend.did
Generating type declarations for canister civic_canister_backend:
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.d.ts
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did.js
  /Users/lilly/civic/demo1/src/declarations/civic_canister_backend/civic_canister_backend.did

Installing canisters...
Installing code for canister relying_canister_frontend, with canister ID vjvbu-faaaa-aaaag-qj5iq-cai
Uploading assets to asset canister...
Fetching properties for all assets in the canister.
Done fetching properties for all assets in the canister. Took 15.5µs
Starting batch.
[31mError: (B[mFailed while trying to deploy canisters.
[33mCaused by: (B[mFailed while trying to install all canisters.
[33mCaused by: (B[mFailed to install wasm module to canister 'relying_canister_frontend'.
[33mCaused by: (B[mFailed to store assets in canister 'relying_canister_frontend'.
[33mCaused by: (B[mFailed asset sync with canister vjvbu-faaaa-aaaag-qj5iq-cai.
[33mCaused by: (B[mFailed to create batch: The replica returned a rejection error: reject code CanisterError, reject message Requested canister has no wasm module, error code Some("IC0537")
```